### PR TITLE
Changed name of arrayOfStringsWithTagPaths to tagPathStrings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,14 +18,14 @@ process.argv.forEach(function (valArg, indexArg) {
   localObj = JSON.parse(fs.readFileSync(valArg))
   //console.log('localObj : ', localObj)
   //console.log(langs)
-  let arrayOfStringsWithTagPath = [] 
+  let tagPathStrings = [] 
     , aPath = `_locales/`
     , srcToLocalize = {}
   srcToLocalize[langs[languageIdx]] = {}
 
-  localObj = addStr(localObj, undefined, arrayOfStringsWithTagPath)
+  localObj = addStr(localObj, undefined, tagPathStrings)
   //console.log('localObj after recursive: ', localObj)
-  //console.log('after loop arrayOfStringsWithTagPath: ', arrayOfStringsWithTagPath)
+  //console.log('after loop tagPathStrings: ', tagPathStrings)
   testTargetObj(localObj)
   //console.log('localObj : ', localObj)
   let srcStr = ""
@@ -33,9 +33,9 @@ process.argv.forEach(function (valArg, indexArg) {
     , keyObj = {}
     , srcObj = {}
   
-  srcStr = makeKeyPathReturnSrc(arrayOfStringsWithTagPath, srcStr, keyArr, srcObj)
+  srcStr = makeKeyPathReturnSrc(tagPathStrings, srcStr, keyArr, srcObj)
   testStr(srcStr)
-  //	console.log('arrayOfStringsWithTagPath after makeKeyPath... func: ', arrayOfStringsWithTagPath)
+  //console.log('tagPathStrings after makeKeyPath... func: ', tagPathStrings)
   //console.log('src Str : ', srcStr)
 
   //console.log('src Obj : ', srcObj)


### PR DESCRIPTION
For issue #3. I'm proposing the variable name be changed to **tagPathStrings**. Feedback is welcome on the naming as I'm not sure if it will be suitable for everyone else.

Also updated the comments to reflect the change, and fixed a small inconsistency with the comment on line 38.

**Note:** I did get the code to run, and got the following output. I think it has to do with how my directories are setup:

Script started.
local_obj.json will be translated into other language version local_obj.json.
./exe.sh: line 37: /usr/bin/expect: No such file or directory
Script done.
